### PR TITLE
replace broken IRIS image 2019.4.0.383.0-zpm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ ARG IMAGE=store/intersystems/irishealth:2019.3.0.308.0-community
 ARG IMAGE=store/intersystems/iris-community:2019.3.0.309.0
 ARG IMAGE=store/intersystems/iris-community:2019.4.0.379.0
 ARG IMAGE=store/intersystems/iris-community:2020.1.0.199.0
-ARG IMAGE=intersystemsdc/iris-community:2019.4.0.383.0-zpm
+# ARG IMAGE=intersystemsdc/iris-community:2019.4.0.383.0-zpm
+ARG IMAGE=intersystemsdc/iris-community:2020.4.0.524.0-zpm
 FROM $IMAGE
 
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ARG IMAGE=store/intersystems/iris-community:2019.4.0.379.0
 ARG IMAGE=store/intersystems/iris-community:2020.1.0.199.0
 # ARG IMAGE=intersystemsdc/iris-community:2019.4.0.383.0-zpm
 ARG IMAGE=intersystemsdc/iris-community:2020.4.0.524.0-zpm
+ARG IMAGE=intersystemsdc/iris-community:latest
 FROM $IMAGE
 
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,11 @@ ARG IMAGE=intersystemsdc/iris-community:2020.4.0.524.0-zpm
 FROM $IMAGE
 
 USER root
-
+ 
 WORKDIR /opt/irisapp
 RUN chown ${ISC_PACKAGE_MGRUSER}:${ISC_PACKAGE_IRISGROUP} /opt/irisapp
 
-USER irisowner
+USER irisowner 
 
 COPY  Installer.cls .
 COPY  src src

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To install using Docker. Follow this instructions:
 Open terminal and clone the repo into any local directory
 
 ```
-$ git https://github.com/intersystems-ru/CDV.git
+$ git clone https://github.com/intersystems-ru/CDV.git
 ```
 
 Open the terminal in this directory and run:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,8 @@ services:
       context: .
       dockerfile: Dockerfile
     restart: always
-    ports: 
+    ports:
+      - 1972
       - 51773
       - 52773
       - 53773


### PR DESCRIPTION
IRIS : 2019.4.0.383.0-zpm leaves with SHELL ["/irissession.sh"]
new changt to :latest to fix licensing issue
~~~
ERROR: Service 'iris' failed to build : 
The command '/irissession.sh chown ${ISC_PACKAGE_MGRUSER}:${ISC_PACKAGE_IRISGROUP} /opt/irisapp' 
returned a non-zero code: 1
~~~
IRIS: 2020.4.0.524.0-zpm   fixed the problem
- requires port 1972

git CLONE fixed in README.md